### PR TITLE
Fix Calendly status variable scope

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -32,7 +32,7 @@ async function bootstrap() {
   }
 
   try {
-    calendlyOk = await connectCalendly();
+    const calendlyOk = await connectCalendly();
     if (!calendlyOk) throw new Error("webhook not live");
   } catch (err) {
     logger.error("Could not connect to Calendly — aborting startup.");


### PR DESCRIPTION
## Summary
- scope `calendlyOk` locally when connecting to Calendly

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d84b3692483329db8a00e04a4ab00